### PR TITLE
use a url safe encoding for the key

### DIFF
--- a/lib/proca_web/resolvers/contact.ex
+++ b/lib/proca_web/resolvers/contact.ex
@@ -54,7 +54,7 @@ defmodule ProcaWeb.Resolvers.Contact do
       action_page ->
         case create_signature(action_page, signature) do
           {:ok, %Signature{id: _signature_id, fingerprint: fpr}} ->
-            {:ok, Base.encode64(fpr)}
+            {:ok, Base.url_encode64(fpr)}
           {:error, %Ecto.Changeset{} = changeset} ->
             {:error, Helper.format_errors(changeset)}
           _ ->


### PR DESCRIPTION
so we can use it for the utm_source and stay compact(ish).

todo @marcinkoziej : change graphql to use url_decode64 on the contactRef attribute

Alternative: we use a url_encode64(uuid v4) as an extra "key" (like I do on the client side when I generate an action without contacts)

from wiki+rfc:

--------------

Using standard Base64 in URL requires encoding of '+', '/' and '=' characters into special percent-encoded hexadecimal sequences ('+' becomes '%2B', '/' becomes '%2F' and '=' becomes '%3D'), which makes the string unnecessarily longer.

For this reason, modified Base64 for URL variants exist (such as base64url in RFC 4648), where the '+' and '/' characters of standard Base64 are respectively replaced by '-' and '_', so that using URL encoders/decoders is no longer necessary and has no impact on the length of the encoded value, leaving the same encoded form intact for use in relational databases, web forms, and object identifiers in general. Some variants allow or require omitting the padding '=' signs to avoid them being confused with field separators, or require that any such padding be percent-encoded. Some libraries will encode '=' to '.', potentially exposing applications to relative path attacks when a folder name is encoded from user data. 